### PR TITLE
Bump agents to 0.3.9 and update lockfile

### DIFF
--- a/workflows/durableAgent/package-lock.json
+++ b/workflows/durableAgent/package-lock.json
@@ -9,14 +9,11 @@
 			"version": "0.0.0",
 			"dependencies": {
 				"@cloudflare/cloudflare-brand-assets": "^4.7.7",
-				"@hono/zod-validator": "^0.7.6",
-				"agents": "^0.3.7",
-				"hono": "^4.11.4",
+				"agents": "^0.3.9",
 				"partysocket": "^1.1.10",
 				"react": "^19.2.3",
 				"react-dom": "^19.2.3",
-				"react-markdown": "^10.1.0",
-				"zod": "^4.3.5"
+				"react-markdown": "^10.1.0"
 			},
 			"devDependencies": {
 				"@cloudflare/vite-plugin": "^1.20.3",
@@ -2541,16 +2538,6 @@
 				"hono": "^4"
 			}
 		},
-		"node_modules/@hono/zod-validator": {
-			"version": "0.7.6",
-			"resolved": "https://registry.npmjs.org/@hono/zod-validator/-/zod-validator-0.7.6.tgz",
-			"integrity": "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==",
-			"license": "MIT",
-			"peerDependencies": {
-				"hono": ">=3.9.0",
-				"zod": "^3.25.0 || ^4.0.0"
-			}
-		},
 		"node_modules/@humanfs/core": {
 			"version": "0.19.1",
 			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -4516,9 +4503,9 @@
 			}
 		},
 		"node_modules/agents": {
-			"version": "0.3.7",
-			"resolved": "https://registry.npmjs.org/agents/-/agents-0.3.7.tgz",
-			"integrity": "sha512-s9NJFv75Vv0rAX+awGwq6Lfn9CWJt935dRcYwfqlAxTJsL4vFCk4cBsK6ptp6Iolv2Etw25Z8eMa2XBq6LS1/w==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/agents/-/agents-0.3.9.tgz",
+			"integrity": "sha512-ffuixXuKlO9+tJKeA8cnZGnDRXRVBYbiJoh875oErw4WO+vg9IwTQAE31WSkXWmtH3XF7p6J6tRyvqMw4tQb1w==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {

--- a/workflows/durableAgent/package.json
+++ b/workflows/durableAgent/package.json
@@ -14,7 +14,7 @@
 	},
 	"dependencies": {
 		"@cloudflare/cloudflare-brand-assets": "^4.7.7",
-		"agents": "^0.3.7",
+		"agents": "^0.3.9",
 		"partysocket": "^1.1.10",
 		"react": "^19.2.3",
 		"react-dom": "^19.2.3",


### PR DESCRIPTION
Update agents dependency from ^0.3.7 to ^0.3.9 in package.json and refresh package-lock.json. The lockfile now reflects the new agents version (updated resolved URL and integrity) and removes stale @hono/zod-validator/zod entries so it matches the current dependency tree.